### PR TITLE
Migrate from pyenv to uv for environment management

### DIFF
--- a/MLproject
+++ b/MLproject
@@ -131,5 +131,5 @@ entry_points:
       future_data: str
       out_file: str
       model_config: str
-python_env: pyenv.yaml
+uv_env: pyproject.toml
 


### PR DESCRIPTION
## Summary
- Switch MLproject to use `uv_env: pyproject.toml` instead of `python_env: pyenv.yaml`

## Test plan
- [x] Verified with `chap evaluate2` command - runs successfully with the new uv environment configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)