### PR TITLE
Persistence skip head + per-location residual scaling

### DIFF
--- a/.github/workflows/python-install-and-test.yml
+++ b/.github/workflows/python-install-and-test.yml
@@ -1,5 +1,5 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# Install with uv (matches local dev setup; pyproject.toml is source of
+# truth) and run pytest.
 
 name: Build and test
 
@@ -16,22 +16,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-        matrix:
-            os: [ubuntu-latest]
-            python-version: ["3.12"]
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.12"]
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: "${{ matrix.python-version }}"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements_dev.txt
-
-        python -m pip install --upgrade pip
-        pip install .
-    - name: Run pytest and doctest
-      run: |
-        make test-all
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+      - name: Sync dependencies
+        run: uv sync --dev
+      - name: Run pytest
+        run: uv run pytest tests/ -v

--- a/.github/workflows/python-install-and-test.yml
+++ b/.github/workflows/python-install-and-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
         matrix:
             os: [ubuntu-latest]
-            python-version: ["3.10"]
+            python-version: ["3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/chtorch/auxilliary_estimator.py
+++ b/chtorch/auxilliary_estimator.py
@@ -30,7 +30,11 @@ class AuxilliaryEstimator(Estimator):
         main_dataset, transformer, target_scaler, val_dataset = super()._get_transformed_dataset(
             data, validation_dataset
         )
-        target_scaler = MultiTargetScaler([target_scaler] + aux_target_scalers)
+        all_scalers = [target_scaler] + aux_target_scalers
+        if all(s is not None for s in all_scalers):
+            target_scaler = MultiTargetScaler(all_scalers)
+        else:
+            target_scaler = None
         datasets = [main_dataset] + aux_datasets
         multi_dataset = MultiDataset(datasets, main_dataset_weight=10)
         return multi_dataset, transformer, target_scaler, val_dataset

--- a/chtorch/data_loader.py
+++ b/chtorch/data_loader.py
@@ -4,19 +4,22 @@ import torch
 import numpy as np
 
 # last_log_rate: un-normalized log1p(rate) at the final historic step,
-# per-sample scalar. Used as a persistence baseline (skip connection) so
-# the model only learns deviations from "stay at the most recent value".
+#   per-sample scalar. Persistence baseline for the skip connection.
+# per_loc_std: per-location std of log1p(rate) over training data,
+#   per-sample scalar. Network output (residual) is multiplied by this
+#   so the model learns deviations from persistence in per-location
+#   sigma units (symmetric per-loc normalisation on the output side).
 Entry = namedtuple(
     'Entry',
-    ['X', 'locations', 'y', 'population', 'past_y', 'last_log_rate'],
+    ['X', 'locations', 'y', 'population', 'past_y', 'last_log_rate', 'per_loc_std'],
 )
-Entry.__new__.__defaults__ = (None,)
+Entry.__new__.__defaults__ = (None, None)
 
 
 class TSDataSet(torch.utils.data.Dataset):
     def __init__(self, X, y, population, context_length,
                  prediction_length, parents=None, indices=None,
-                 augmentations=None, transformer=None):
+                 augmentations=None, transformer=None, per_loc_std=None):
         if y is not None:
             assert y.shape == population.shape, f"y and population should have the same shape, got {y.shape} and {population.shape}"
         self.X = X  # time, location, feature
@@ -32,6 +35,11 @@ class TSDataSet(torch.utils.data.Dataset):
         self.augmentations = augmentations if augmentations is not None else []
         self.indices = indices
         self.transformer = transformer
+        # per_loc_std: (n_locations,) — std of log1p(rate) per location over
+        # training data. None defaults to 1.0 (no scaling on residual).
+        self.per_loc_std = (
+            per_loc_std.astype(np.float32) if per_loc_std is not None else None
+        )
 
     def _transform_x(self, x):
         if self.transformer is not None:
@@ -62,7 +70,7 @@ class TSDataSet(torch.utils.data.Dataset):
             indices = np.asanyarray(self.indices)[indices]
         return self.__class__(self.X, self.y, self.population, self.context_length, self.prediction_length,
                               parents=self.parents, indices=indices, augmentations=self.augmentations,
-                              transformer=self.transformer)
+                              transformer=self.transformer, per_loc_std=self.per_loc_std)
 
     def __len__(self):
         if self.indices is not None:
@@ -104,6 +112,7 @@ class FlatTSDataSet(TSDataSet):
         # Tensorifier puts target_column as the last feature (un-normalized
         # log1p of incidence rate). Grab it BEFORE _transform_x scales x.
         last_log_rate = np.float32(self.X[i + self.context_length - 1, j, -1])
+        ploc_std = np.float32(self.per_loc_std[j]) if self.per_loc_std is not None else np.float32(1.0)
         x = self.X[i:i + self.context_length, j]
         x = self._transform_x(x)
         y = self.y[i + self.context_length:i + self.total_length, j]
@@ -112,7 +121,7 @@ class FlatTSDataSet(TSDataSet):
         assert y.shape == population.shape, f"y and population should have the same shape, got {y.shape} and {population.shape}"
         p = self.parents[j]
         locations = np.array([(j, p) for _ in range(self.context_length)])
-        output = Entry(x, locations, y, population, past_y, last_log_rate)
+        output = Entry(x, locations, y, population, past_y, last_log_rate, ploc_std)
         for augmentation in self.augmentations:
             output = augmentation.transform(output)
         return output
@@ -126,6 +135,10 @@ class FlatTSDataSet(TSDataSet):
         # Per-location persistence baseline = most recent un-normalized
         # target_column (the last feature of X).
         last_log_rate = self.X[-1, :, -1].astype(np.float32)
+        if self.per_loc_std is not None:
+            ploc_std = self.per_loc_std.astype(np.float32)
+        else:
+            ploc_std = np.ones(self.n_locations, dtype=np.float32)
         x = self.X[-self.context_length:, ...].swapaxes(0, 1)
         shape = x.shape
         x = self._transform_x(x.reshape(-1, shape[-1])).reshape(shape)
@@ -134,7 +147,8 @@ class FlatTSDataSet(TSDataSet):
                      None,
                      torch.from_numpy(repeated_population),
                      None,
-                     torch.from_numpy(last_log_rate))
+                     torch.from_numpy(last_log_rate),
+                     torch.from_numpy(ploc_std))
 
 
 class MultiDataset(torch.utils.data.Dataset):

--- a/chtorch/data_loader.py
+++ b/chtorch/data_loader.py
@@ -3,7 +3,14 @@ from collections import namedtuple
 import torch
 import numpy as np
 
-Entry = namedtuple('Entry', ['X', 'locations', 'y', 'population', 'past_y'])
+# last_log_rate: un-normalized log1p(rate) at the final historic step,
+# per-sample scalar. Used as a persistence baseline (skip connection) so
+# the model only learns deviations from "stay at the most recent value".
+Entry = namedtuple(
+    'Entry',
+    ['X', 'locations', 'y', 'population', 'past_y', 'last_log_rate'],
+)
+Entry.__new__.__defaults__ = (None,)
 
 
 class TSDataSet(torch.utils.data.Dataset):
@@ -94,6 +101,9 @@ class FlatTSDataSet(TSDataSet):
         if self.indices is not None:
             item = self.indices[item]
         i, j = divmod(item, self.X.shape[1])
+        # Tensorifier puts target_column as the last feature (un-normalized
+        # log1p of incidence rate). Grab it BEFORE _transform_x scales x.
+        last_log_rate = np.float32(self.X[i + self.context_length - 1, j, -1])
         x = self.X[i:i + self.context_length, j]
         x = self._transform_x(x)
         y = self.y[i + self.context_length:i + self.total_length, j]
@@ -102,7 +112,7 @@ class FlatTSDataSet(TSDataSet):
         assert y.shape == population.shape, f"y and population should have the same shape, got {y.shape} and {population.shape}"
         p = self.parents[j]
         locations = np.array([(j, p) for _ in range(self.context_length)])
-        output = Entry(x, locations, y, population, past_y)
+        output = Entry(x, locations, y, population, past_y, last_log_rate)
         for augmentation in self.augmentations:
             output = augmentation.transform(output)
         return output
@@ -113,15 +123,18 @@ class FlatTSDataSet(TSDataSet):
         location_row = np.array([self.locations[0].ravel(), self.parents]).T
         location = np.array([location_row for _ in range(self.context_length)]).swapaxes(0, 1)
         assert location.shape == (self.n_locations, self.context_length, 2), location.shape
+        # Per-location persistence baseline = most recent un-normalized
+        # target_column (the last feature of X).
+        last_log_rate = self.X[-1, :, -1].astype(np.float32)
         x = self.X[-self.context_length:, ...].swapaxes(0, 1)
         shape = x.shape
         x = self._transform_x(x.reshape(-1, shape[-1])).reshape(shape)
-        # Entry = namedtuple('Entry', ['X', 'locations', 'y', 'population', 'past_y'])
         return Entry(torch.from_numpy(x),
                      torch.from_numpy(location),
                      None,
                      torch.from_numpy(repeated_population),
-                     None)
+                     None,
+                     torch.from_numpy(last_log_rate))
 
 
 class MultiDataset(torch.utils.data.Dataset):
@@ -155,11 +168,11 @@ class MultiDataset(torch.utils.data.Dataset):
 
     def __getitem__(self, item):
         dataset_idx, new_idx = self._split_index(item)
-        x, locations, y, population, past_y = self.datasets[dataset_idx][new_idx]
-        locations = locations.copy()
+        entry = self.datasets[dataset_idx][new_idx]
+        locations = entry.locations.copy()
         locations[:, 0] += self._category_offsets[dataset_idx]
         locations[:, 1] = dataset_idx
-        output = Entry(x, locations, y, population, past_y)
+        output = entry._replace(locations=locations)
         for augmentation in self.augmentations:
             output = augmentation.transform(output)
         return output

--- a/chtorch/distribution_loss.py
+++ b/chtorch/distribution_loss.py
@@ -39,14 +39,24 @@ class MaskedNANLoss(abc.ABC, nn.Module):
 
 
 _MIN_TOTAL_COUNT = 1e-6
+_MAX_TOTAL_COUNT = 1e8
 
 
 def _safe_total_count(eta, population, count_transform):
-    """Convert (eta, population) to NB total_count, clamped to a tiny
-    positive floor so torch.distributions.NegativeBinomial stays valid even
-    when the predicted mean is exactly 0."""
+    """Convert (eta, population) to NB total_count, clamped to a safe finite
+    range. Without the persistence skip the network can output very large or
+    very negative eta values at the start of training, which combined with
+    expm1(·) overflows or makes total_count negative / NaN. clamp + nan_to_num
+    keeps torch.distributions.NegativeBinomial valid."""
     mean = count_transform.inverse(eta[..., 0], population)
-    return (mean / torch.exp(eta[..., 1])).clamp_min(_MIN_TOTAL_COUNT)
+    total = mean / torch.exp(eta[..., 1])
+    total = torch.nan_to_num(
+        total,
+        nan=_MIN_TOTAL_COUNT,
+        posinf=_MAX_TOTAL_COUNT,
+        neginf=_MIN_TOTAL_COUNT,
+    )
+    return total.clamp(min=_MIN_TOTAL_COUNT, max=_MAX_TOTAL_COUNT)
 
 
 class NegativeBinomialLoss(MaskedNANLoss):

--- a/chtorch/estimator.py
+++ b/chtorch/estimator.py
@@ -306,7 +306,12 @@ class Estimator(ModelBase):
         transformer.fit(array_dataset.reshape(-1, input_features))
         X = array_dataset.astype(np.float32)
         y = np.array([series.disease_cases for series in data.values()]).T
-        target_scaler = TargetScaler(self.count_transform.forward(y, population))
+        # Drop the per-location TargetScaler: with IncidenceRateTransform the
+        # model output already lives in log1p(rate) space, which is the same
+        # scale as the StandardScaler-normalised AR input. The previous
+        # per-location rescale created an asymmetry (global-stats input,
+        # per-loc-stats output) that dampened the model's surge response.
+        target_scaler = None
 
         if self.problem_configuration.replace_zeros:
             y = np.where(y == 0, np.nan, y)

--- a/chtorch/estimator.py
+++ b/chtorch/estimator.py
@@ -69,7 +69,8 @@ class Predictor(ModelBase):
     def __init__(self, module,
                  predictor_info: PredictorInfo,
                  transformer: StandardScaler,
-                 target_scaler=None):
+                 target_scaler=None,
+                 per_loc_std=None):
         super().__init__()
         problem_configuration = predictor_info.problem_configuration
         model_configuration = predictor_info.model_configuration
@@ -83,7 +84,9 @@ class Predictor(ModelBase):
         self.count_transform = IncidenceRateTransform()
         self._loss_class = self._get_loss_class()
         self._target_scaler = target_scaler
-        # assert target_scaler is not None, target_scaler
+        # Per-location std of log1p(rate), shape (n_locations,). Used to
+        # scale the network's residual at predict time. None = identity.
+        self._per_loc_std = per_loc_std
 
     def save(self, path: Path | str):
         path = Path(path)
@@ -91,6 +94,8 @@ class Predictor(ModelBase):
         dump(self.transformer, path.with_suffix('.transformer'))
         if self._target_scaler is not None:
             dump(self._target_scaler, path.with_suffix('.target_scaler'))
+        if self._per_loc_std is not None:
+            dump(self._per_loc_std, path.with_suffix('.per_loc_std'))
         with open(path.with_suffix('.predictor_info.json'), 'w') as f:
             f.write(self._predictor_info.model_dump_json())
 
@@ -109,20 +114,23 @@ class Predictor(ModelBase):
         transformer = load(path.with_suffix('.transformer'))
         scaler_path = path.with_suffix('.target_scaler')
         target_scaler = load(scaler_path) if scaler_path.exists() else None
+        ploc_std_path = path.with_suffix('.per_loc_std')
+        per_loc_std = load(ploc_std_path) if ploc_std_path.exists() else None
         return cls(module,
                    predictor_info,
                    transformer,
-                   target_scaler=target_scaler)
+                   target_scaler=target_scaler,
+                   per_loc_std=per_loc_std)
 
     def predict(self, historic_data: DataSet, future_data: DataSet):
         historic_tensor, population, parents = self._get_prediction_dataset(historic_data)
         historic_tensor = historic_tensor.astype(np.float32)
         _DataSet = TSDataSet if not self.is_flat else FlatTSDataSet
         ts_dataset = _DataSet(historic_tensor, None, population, self.context_length, self.problem_configuration.prediction_length, parents,
-                              transformer=self.transformer)
+                              transformer=self.transformer, per_loc_std=self._per_loc_std)
         batch = ts_dataset.last_prediction_instance()
         with torch.no_grad():
-            eta, *_ = self.module(batch.X, batch.locations, last_log_rate=batch.last_log_rate)
+            eta, *_ = self.module(batch.X, batch.locations, last_log_rate=batch.last_log_rate, per_loc_std=batch.per_loc_std)
             if self._target_scaler is not None:
                 locations = batch.locations[:, 0, 0]
                 assert len(np.unique(locations)) == len(locations)
@@ -266,7 +274,8 @@ class Estimator(ModelBase):
                                       n_categories=train_dataset.n_categories,
                                       output_dim=output_dim),
                                   transformer,
-                                  target_scaler=target_scaler)
+                                  target_scaler=target_scaler,
+                                  per_loc_std=getattr(train_dataset, 'per_loc_std', None))
 
     def add_validation(self, val_dataset: DataSet):
         self._validation_dataset = val_dataset
@@ -306,11 +315,15 @@ class Estimator(ModelBase):
         transformer.fit(array_dataset.reshape(-1, input_features))
         X = array_dataset.astype(np.float32)
         y = np.array([series.disease_cases for series in data.values()]).T
-        # Drop the per-location TargetScaler: with IncidenceRateTransform the
-        # model output already lives in log1p(rate) space, which is the same
-        # scale as the StandardScaler-normalised AR input. The previous
-        # per-location rescale created an asymmetry (global-stats input,
-        # per-loc-stats output) that dampened the model's surge response.
+        # Per-location std of log1p(rate) — used to scale the network's
+        # residual output (symmetric per-loc normalisation on the output side).
+        # The persistence skip provides the per-loc baseline; this provides
+        # the per-loc unit.
+        y_log_rate = self.count_transform.forward(y, population)
+        per_loc_std = np.nanstd(y_log_rate, axis=0)
+        per_loc_std = np.where(
+            (per_loc_std == 0) | np.isnan(per_loc_std), 1.0, per_loc_std
+        ).astype(np.float32)
         target_scaler = None
 
         if self.problem_configuration.replace_zeros:
@@ -319,7 +332,7 @@ class Estimator(ModelBase):
         assert len(X) == len(y)
 
         train_dataset = FlatTSDataSet(X, y, population, self.context_length, self.problem_configuration.prediction_length, parents,
-                                      transformer=transformer)
+                                      transformer=transformer, per_loc_std=per_loc_std)
         if validation_dataset is not None:
             val_array_dataset, val_population, _ = self.tensorifier.convert(validation_dataset)
             val_X = val_array_dataset.astype(np.float32)
@@ -331,7 +344,7 @@ class Estimator(ModelBase):
                 full_X, full_y, full_population,
                 self.context_length,
                 self.problem_configuration.prediction_length, parents,
-                transformer=transformer)
+                transformer=transformer, per_loc_std=per_loc_std)
             true_length = (len(validation_dataset.period_range) - self.problem_configuration.prediction_length + 1) * len(
                 validation_dataset.locations())
             logger.info(

--- a/chtorch/estimator.py
+++ b/chtorch/estimator.py
@@ -122,7 +122,7 @@ class Predictor(ModelBase):
                               transformer=self.transformer)
         batch = ts_dataset.last_prediction_instance()
         with torch.no_grad():
-            eta, *_ = self.module(batch.X, batch.locations)
+            eta, *_ = self.module(batch.X, batch.locations, last_log_rate=batch.last_log_rate)
             if self._target_scaler is not None:
                 locations = batch.locations[:, 0, 0]
                 assert len(np.unique(locations)) == len(locations)

--- a/chtorch/lightning_module.py
+++ b/chtorch/lightning_module.py
@@ -39,7 +39,7 @@ class DeepARLightningModule(L.LightningModule):
         return self.module(*args, **kwargs)
 
     def training_step(self, batch, batch_idx):
-        eta, past_eta = self.module(batch.X, batch.locations)
+        eta, past_eta = self.module(batch.X, batch.locations, last_log_rate=batch.last_log_rate)
         if self._target_scaler is not None:
             log_rate = self._target_scaler.scale_by_location(batch.locations[:, 0, 0], eta)
             past_log_rate = self._target_scaler.scale_by_location(batch.locations[:, 0, 0], past_eta)
@@ -55,7 +55,7 @@ class DeepARLightningModule(L.LightningModule):
 
     def validation_step(self, batch, batch_idx):
         with torch.no_grad():
-            log_rate, *_ = self.module(batch.X, batch.locations)
+            log_rate, *_ = self.module(batch.X, batch.locations, last_log_rate=batch.last_log_rate)
             assert not torch.isnan(log_rate).any()
             if self._target_scaler is not None:
                 log_rate = self._target_scaler.scale_by_location(batch.locations[:, 0, 0], log_rate)

--- a/chtorch/lightning_module.py
+++ b/chtorch/lightning_module.py
@@ -39,7 +39,7 @@ class DeepARLightningModule(L.LightningModule):
         return self.module(*args, **kwargs)
 
     def training_step(self, batch, batch_idx):
-        eta, past_eta = self.module(batch.X, batch.locations, last_log_rate=batch.last_log_rate)
+        eta, past_eta = self.module(batch.X, batch.locations, last_log_rate=batch.last_log_rate, per_loc_std=batch.per_loc_std)
         if self._target_scaler is not None:
             log_rate = self._target_scaler.scale_by_location(batch.locations[:, 0, 0], eta)
             past_log_rate = self._target_scaler.scale_by_location(batch.locations[:, 0, 0], past_eta)
@@ -55,7 +55,7 @@ class DeepARLightningModule(L.LightningModule):
 
     def validation_step(self, batch, batch_idx):
         with torch.no_grad():
-            log_rate, *_ = self.module(batch.X, batch.locations, last_log_rate=batch.last_log_rate)
+            log_rate, *_ = self.module(batch.X, batch.locations, last_log_rate=batch.last_log_rate, per_loc_std=batch.per_loc_std)
             assert not torch.isnan(log_rate).any()
             if self._target_scaler is not None:
                 log_rate = self._target_scaler.scale_by_location(batch.locations[:, 0, 0], log_rate)

--- a/chtorch/module.py
+++ b/chtorch/module.py
@@ -150,7 +150,7 @@ class RNNWithLocationEmbedding(nn.Module):
 
 class FlatRNN(RNNWithLocationEmbedding):
 
-    def forward(self, x, locations, last_log_rate=None):
+    def forward(self, x, locations, last_log_rate=None, per_loc_std=None):
         offset_time = True
         batch_size, time_steps, feature_dim = x.shape
         total_length = self.prediction_length + time_steps - 1
@@ -175,16 +175,20 @@ class FlatRNN(RNNWithLocationEmbedding):
 
         reshaped = decoded.reshape(batch_size, total_length, self.output_dim)
 
-        # Persistence skip: add the un-normalized log1p-rate from the final
-        # historic step to the mean head. Network output is now the
-        # *deviation* from "stay at the most recent value" — eta_mean=0
-        # predicts the last observation. The dispersion logit (channel 1)
-        # and any extra channels are untouched.
+        # Persistence skip + per-location residual unit:
+        #   eta_mean = network_out * per_loc_std + last_log_rate
+        # network_out=0 ⇒ predict last observation; non-zero outputs are
+        # interpreted as deviations in per-location sigma units of
+        # log1p(rate). Only the mean channel is touched; the dispersion
+        # logit (channel 1) and any extra channels are untouched.
         if last_log_rate is not None:
             llr = last_log_rate.to(dtype=reshaped.dtype, device=reshaped.device)
-            # llr shape: (batch,) → (batch, 1, 1) so it broadcasts over time
             llr = llr.reshape(batch_size, 1, 1)
-            mean_channel = reshaped[..., :1] + llr
+            mean_channel = reshaped[..., :1]
+            if per_loc_std is not None:
+                pls = per_loc_std.to(dtype=reshaped.dtype, device=reshaped.device)
+                mean_channel = mean_channel * pls.reshape(batch_size, 1, 1)
+            mean_channel = mean_channel + llr
             reshaped = torch.cat([mean_channel, reshaped[..., 1:]], dim=-1)
 
         return (reshaped[:, -self.prediction_length:].squeeze(-1),

--- a/chtorch/module.py
+++ b/chtorch/module.py
@@ -150,7 +150,7 @@ class RNNWithLocationEmbedding(nn.Module):
 
 class FlatRNN(RNNWithLocationEmbedding):
 
-    def forward(self, x, locations):
+    def forward(self, x, locations, last_log_rate=None):
         offset_time = True
         batch_size, time_steps, feature_dim = x.shape
         total_length = self.prediction_length + time_steps - 1
@@ -174,6 +174,18 @@ class FlatRNN(RNNWithLocationEmbedding):
         decoded = self.output_layer(decoded)
 
         reshaped = decoded.reshape(batch_size, total_length, self.output_dim)
+
+        # Persistence skip: add the un-normalized log1p-rate from the final
+        # historic step to the mean head. Network output is now the
+        # *deviation* from "stay at the most recent value" — eta_mean=0
+        # predicts the last observation. The dispersion logit (channel 1)
+        # and any extra channels are untouched.
+        if last_log_rate is not None:
+            llr = last_log_rate.to(dtype=reshaped.dtype, device=reshaped.device)
+            # llr shape: (batch,) → (batch, 1, 1) so it broadcasts over time
+            llr = llr.reshape(batch_size, 1, 1)
+            mean_channel = reshaped[..., :1] + llr
+            reshaped = torch.cat([mean_channel, reshaped[..., 1:]], dim=-1)
 
         return (reshaped[:, -self.prediction_length:].squeeze(-1),
                 reshaped[:, :-self.prediction_length].squeeze(-1))

--- a/chtorch/module.py
+++ b/chtorch/module.py
@@ -75,6 +75,11 @@ class RNNConfiguration(BaseModel):
     output_embedding_dim: int = 0 # Capacity
     dropout: float = 0.0 # Regulatization
     direct_ar: bool = False # Convergence
+    # If True, the mean head predicts in terms of a per-location persistence
+    # baseline + a per-location-std-scaled residual:
+    #     eta_mean = network_out * per_loc_std + last_log_rate
+    # If False, the model emits eta directly (no skip, no residual scaling).
+    persistence_skip: bool = True
 
 
 class RNNWithLocationEmbedding(nn.Module):
@@ -119,6 +124,7 @@ class RNNWithLocationEmbedding(nn.Module):
         #self.ouput_layer = MLP(cfg.n_hidden, cfg.n_hidden, self.output_dim, cfg.n_layers, dropout=cfg.dropout)
         self.output_layer = FeatureCompressor(dim, cfg.max_dim, self.output_dim, dropout=cfg.dropout)
         self.prediction_length = prediction_length
+        self.persistence_skip = cfg.persistence_skip
 
     def forward(self, x, locations):
         """
@@ -175,13 +181,13 @@ class FlatRNN(RNNWithLocationEmbedding):
 
         reshaped = decoded.reshape(batch_size, total_length, self.output_dim)
 
-        # Persistence skip + per-location residual unit:
+        # Persistence skip + per-location residual unit (gated by cfg flag):
         #   eta_mean = network_out * per_loc_std + last_log_rate
         # network_out=0 ⇒ predict last observation; non-zero outputs are
         # interpreted as deviations in per-location sigma units of
-        # log1p(rate). Only the mean channel is touched; the dispersion
-        # logit (channel 1) and any extra channels are untouched.
-        if last_log_rate is not None:
+        # log1p(rate). When persistence_skip=False (or batch lacks
+        # last_log_rate), the mean channel passes through unchanged.
+        if self.persistence_skip and last_log_rate is not None:
             llr = last_log_rate.to(dtype=reshaped.dtype, device=reshaped.device)
             llr = llr.reshape(batch_size, 1, 1)
             mean_channel = reshaped[..., :1]

--- a/scripts/analyse_eval.py
+++ b/scripts/analyse_eval.py
@@ -1,0 +1,100 @@
+"""Quick analysis of vnm_monthly_eval.nc — surface obvious failure modes:
+- Are predicted samples in the right ballpark?
+- Per-location bias / scale errors
+- Are samples degenerate (constant, all zero, exploded)?
+"""
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+NC = Path("/Users/knutdr/Sources/chtorch/vnm_monthly_eval.nc")
+CSV = Path("/Users/knutdr/Downloads/chap_VNM_admin1_monthly.csv")
+
+
+def main():
+    ds = xr.open_dataset(NC)
+    print("== NetCDF variables ==")
+    for name, v in ds.data_vars.items():
+        print(f"  {name:20s} dims={v.dims} shape={v.shape} dtype={v.dtype}")
+    print("\n== Coords ==")
+    for name, c in ds.coords.items():
+        print(f"  {name:20s} size={c.size}")
+
+    samples = ds["forecast"]
+    truth = ds["observed"]
+    # Broadcast truth across horizon for fair per-(time,horizon) comparison
+    truth = truth.expand_dims({"horizon_distance": samples.sizes["horizon_distance"]}, axis=-1)
+    sample_dim = "sample"
+    print(f"\nsamples.shape = {samples.shape}")
+    print(f"truth.shape   = {truth.shape}")
+
+    pred_mean = samples.mean(sample_dim)
+    pred_med = samples.median(sample_dim)
+    pred_std = samples.std(sample_dim)
+
+    # Flatten across split/period/location for global stats, drop NaN truth
+    truth_flat = truth.values.ravel().astype(float)
+    mean_flat = pred_mean.values.ravel().astype(float)
+    med_flat = pred_med.values.ravel().astype(float)
+    std_flat = pred_std.values.ravel().astype(float)
+    mask = ~np.isnan(truth_flat)
+    truth_flat = truth_flat[mask]
+    mean_flat = mean_flat[mask]
+    med_flat = med_flat[mask]
+    std_flat = std_flat[mask]
+
+    print("\n== Truth vs prediction (all points) ==")
+    print(f"truth   :  min {truth_flat.min():.1f}  median {np.median(truth_flat):.1f}  mean {truth_flat.mean():.1f}  max {truth_flat.max():.1f}")
+    print(f"pred mu :  min {mean_flat.min():.1f}  median {np.median(mean_flat):.1f}  mean {mean_flat.mean():.1f}  max {mean_flat.max():.1f}")
+    print(f"pred med:  min {med_flat.min():.1f}  median {np.median(med_flat):.1f}  mean {med_flat.mean():.1f}  max {med_flat.max():.1f}")
+    print(f"pred sd :  min {std_flat.min():.1f}  median {np.median(std_flat):.1f}  mean {std_flat.mean():.1f}  max {std_flat.max():.1f}")
+
+    # Error metrics
+    err = mean_flat - truth_flat
+    abs_err = np.abs(err)
+    print("\n== Error metrics (mean prediction vs truth) ==")
+    print(f"bias (mean err): {err.mean():.2f}")
+    print(f"MAE            : {abs_err.mean():.2f}")
+    print(f"RMSE           : {np.sqrt((err**2).mean()):.2f}")
+    nz = truth_flat > 0
+    if nz.any():
+        smape = 2 * np.abs(mean_flat[nz] - truth_flat[nz]) / (np.abs(mean_flat[nz]) + np.abs(truth_flat[nz]) + 1e-9)
+        print(f"SMAPE (truth>0): {smape.mean():.3f}")
+
+    # Per-location bias (across all splits)
+    if 'location' in samples.dims:
+        per_loc_mean_pred = pred_mean.mean([d for d in pred_mean.dims if d != 'location']).values
+        per_loc_mean_truth = truth.mean([d for d in truth.dims if d != 'location']).values
+        ratio = per_loc_mean_pred / np.maximum(per_loc_mean_truth, 1e-3)
+        print("\n== Per-location ratio (pred_mean / truth_mean), first 10 locations ==")
+        for i in range(min(10, len(ratio))):
+            print(f"  loc {i:3d}: pred={per_loc_mean_pred[i]:.2f}  truth={per_loc_mean_truth[i]:.2f}  ratio={ratio[i]:.2f}")
+
+    # Sample dispersion check — are samples actually varying?
+    print("\n== Sample dispersion summary ==")
+    cv = pred_std.values / np.maximum(pred_mean.values, 1e-3)
+    cv_flat = cv.ravel()
+    cv_flat = cv_flat[~np.isnan(cv_flat)]
+    print(f"coefficient of variation (sd/mu): median {np.median(cv_flat):.3f}  p5 {np.percentile(cv_flat,5):.3f}  p95 {np.percentile(cv_flat,95):.3f}")
+
+
+def dataset_stats():
+    df = pd.read_csv(CSV)
+    print("\n== Dataset stats ==")
+    print(f"rows={len(df)}  locations={df['location'].nunique()}  periods={df['time_period'].nunique()}")
+    by_loc = df.groupby('location')['disease_cases']
+    means = by_loc.mean()
+    zeros = (df['disease_cases'] == 0).mean()
+    nans = df['disease_cases'].isna().mean()
+    print(f"frac zero cases: {zeros:.3f}    frac NaN: {nans:.3f}")
+    print(f"per-loc mean cases: min {means.min():.1f}  median {means.median():.1f}  mean {means.mean():.1f}  max {means.max():.1f}")
+    print(f"per-loc max cases:  median {by_loc.max().median():.0f}  p95 {by_loc.max().quantile(0.95):.0f}  max {by_loc.max().max():.0f}")
+
+
+if __name__ == "__main__":
+    main()
+    dataset_stats()

--- a/scripts/bench_train.py
+++ b/scripts/bench_train.py
@@ -23,6 +23,7 @@ from chtorch.estimator import Estimator
 class TimingCallback(L.Callback):
     def __init__(self):
         self.epoch_times = []
+        self.epoch_losses = []
         self._t0 = None
 
     def on_train_epoch_start(self, trainer, pl_module):
@@ -32,6 +33,9 @@ class TimingCallback(L.Callback):
         if self._t0 is not None:
             self.epoch_times.append(time.perf_counter() - self._t0)
             self._t0 = None
+        loss = trainer.callback_metrics.get('train_loss')
+        if loss is not None:
+            self.epoch_losses.append(float(loss))
 
 
 def main():
@@ -97,6 +101,9 @@ def main():
         et = timing_cb.epoch_times
         print(f"per-epoch:        min {min(et):.2f}s  median {sorted(et)[len(et)//2]:.2f}s  max {max(et):.2f}s  total {sum(et):.2f}s")
         print(f"#epochs measured: {len(et)}")
+    if timing_cb.epoch_losses:
+        ls = timing_cb.epoch_losses
+        print(f"train_loss epochs ({len(ls)}): " + " ".join(f"{x:.3f}" for x in ls))
     print(f"profile dumped:   {args.profile_out}")
 
     # Print top hotspots inline.

--- a/scripts/bench_train_val.py
+++ b/scripts/bench_train_val.py
@@ -1,0 +1,100 @@
+"""Train with validation hold-out and log per-epoch train/val loss.
+
+Use this to answer: is the current setup undertrained at N epochs?
+Holds out the last 3 months (default) as validation, trains for the
+requested number of epochs, prints both loss trajectories at the end.
+"""
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+
+import lightning as L
+import yaml
+from chap_core.assessment.dataset_splitting import train_test_generator
+from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
+
+from chtorch.configuration import ModelConfiguration, ProblemConfiguration
+from chtorch.estimator import Estimator
+
+
+class LossLogger(L.Callback):
+    def __init__(self):
+        self.train = []
+        self.val = []
+        self._t0 = None
+        self.epoch_times = []
+
+    def on_train_epoch_start(self, trainer, pl_module):
+        self._t0 = time.perf_counter()
+
+    def on_train_epoch_end(self, trainer, pl_module):
+        if self._t0 is not None:
+            self.epoch_times.append(time.perf_counter() - self._t0)
+            self._t0 = None
+        tl = trainer.callback_metrics.get('train_loss')
+        if tl is not None:
+            self.train.append(float(tl))
+
+    def on_validation_epoch_end(self, trainer, pl_module):
+        vl = trainer.callback_metrics.get('validation_loss')
+        if vl is not None:
+            self.val.append(float(vl))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data", default="/Users/knutdr/Downloads/chap_VNM_admin1_monthly.csv")
+    parser.add_argument("--config", default="/Users/knutdr/Sources/chtorch/vnm_monthly_config.yaml")
+    parser.add_argument("--max-epochs", type=int, default=200)
+    parser.add_argument("--prediction-length", type=int, default=3)
+    args = parser.parse_args()
+
+    cfg_raw = yaml.safe_load(Path(args.config).read_text())
+    user_opts = dict(cfg_raw.get("user_option_values", {}))
+    user_opts["max_epochs"] = args.max_epochs
+    additional = cfg_raw.get("additional_continuous_covariates", [])
+    model_cfg = ModelConfiguration(**user_opts, additional_covariates=additional)
+    prob_cfg = ProblemConfiguration(prediction_length=args.prediction_length, validate=True)
+
+    dataset = DataSet.from_csv(args.data)
+    train_dataset, val_generator = train_test_generator(
+        dataset, prediction_length=args.prediction_length, n_test_sets=1
+    )
+    validation_dataset = next(val_generator)[-1]
+
+    estimator = Estimator(prob_cfg, model_cfg)
+    estimator.add_validation(validation_dataset)
+
+    logger_cb = LossLogger()
+    orig_init = L.Trainer.__init__
+
+    def patched(self, *a, **kw):
+        cbs = list(kw.get("callbacks") or [])
+        cbs.append(logger_cb)
+        kw["callbacks"] = cbs
+        return orig_init(self, *a, **kw)
+    L.Trainer.__init__ = patched
+
+    estimator.train(train_dataset)
+
+    print()
+    print("==== SUMMARY ====")
+    print(f"epochs measured: {len(logger_cb.train)} train, {len(logger_cb.val)} val")
+    if logger_cb.epoch_times:
+        et = logger_cb.epoch_times
+        print(f"per-epoch wall: median {sorted(et)[len(et)//2]:.2f}s  total {sum(et):.1f}s")
+
+    print("\nepoch  train_loss  val_loss")
+    n = max(len(logger_cb.train), len(logger_cb.val))
+    every = max(1, n // 25)  # print ~25 rows
+    for i in range(n):
+        if i % every == 0 or i == n - 1:
+            tl = f"{logger_cb.train[i]:.4f}" if i < len(logger_cb.train) else " -- "
+            vl = f"{logger_cb.val[i]:.4f}" if i < len(logger_cb.val) else " -- "
+            print(f"{i:5d}   {tl:>10s}   {vl:>10s}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/inspect_decay.py
+++ b/scripts/inspect_decay.py
@@ -1,0 +1,55 @@
+"""Show which parameters end up in which weight-decay group, and the
+post-training norms of the location embeddings, to confirm whether
+location_embeddings.0.weight is being over-regularized.
+"""
+import torch
+
+from chtorch.configuration import ModelConfiguration, ProblemConfiguration
+from chtorch.estimator import Estimator
+from chtorch.lightning_module import DeepARLightningModule
+
+
+def main():
+    # Tiny synthetic to get a module quickly
+    import numpy as np
+    from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
+    dataset = DataSet.from_csv('/Users/knutdr/Downloads/chap_VNM_admin1_monthly.csv')
+
+    model_cfg = ModelConfiguration(context_length=12, embed_dim=4, n_hidden=16,
+                                    state_dim=16, num_rnn_layers=1, max_dim=32,
+                                    output_embedding_dim=0, dropout=0.1,
+                                    weight_decay=1e-5, max_epochs=1,
+                                    additional_covariates=['rainfall', 'mean_temperature', 'mean_relative_humidity'])
+    prob_cfg = ProblemConfiguration(prediction_length=3, debug=True)
+
+    estimator = Estimator(prob_cfg, model_cfg)
+    predictor = estimator.train(dataset)
+    module = predictor.module
+
+    # Reconstruct decay groups
+    weight_decay = model_cfg.weight_decay
+    decay, embed_decay, level_2_decay, no_decay = [], [], [], []
+    for name, param in module.named_parameters():
+        if not param.requires_grad:
+            continue
+        if name.endswith('bias') or 'norm' in name.lower():
+            bucket = 'no_decay'; no_decay.append((name, param))
+        elif 'embed' in name:
+            if '.0.' in name:
+                bucket = 'level_2 (×100)'; level_2_decay.append((name, param))
+            else:
+                bucket = 'embed (×10)'; embed_decay.append((name, param))
+        else:
+            bucket = 'normal (×1)'; decay.append((name, param))
+        norm = param.detach().norm().item()
+        print(f"  {bucket:18s} wd={weight_decay * (100 if '×100' in bucket else 10 if '×10' in bucket else 1 if '×1' in bucket else 0):.0e}  {name:60s} shape={tuple(param.shape)}  L2={norm:.3f}")
+
+    print("\n== Critical embeddings ==")
+    for name, p in level_2_decay + embed_decay:
+        if 'location_embeddings' in name:
+            row_norms = p.detach().norm(dim=1)
+            print(f"  {name:50s} per-row L2 mean={row_norms.mean():.4f}  min={row_norms.min():.4f}  max={row_norms.max():.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/inspect_eval.py
+++ b/scripts/inspect_eval.py
@@ -1,0 +1,55 @@
+"""Look at top-cases locations to see if the model captures dynamic range."""
+from pathlib import Path
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+NC = Path("/Users/knutdr/Sources/chtorch/vnm_monthly_eval.nc")
+CSV = Path("/Users/knutdr/Downloads/chap_VNM_admin1_monthly.csv")
+
+
+def main():
+    ds = xr.open_dataset(NC)
+    df = pd.read_csv(CSV)
+    by_loc = df.groupby('location')['disease_cases']
+
+    # Build location-id → name mapping
+    name_by_loc = df.groupby('location')['location_name'].first().to_dict()
+
+    locations = ds.coords['location'].values
+    samples = ds['forecast']
+    truth = ds['observed']
+
+    pred_med = samples.median('sample')
+    pred_q05 = samples.quantile(0.05, dim='sample')
+    pred_q95 = samples.quantile(0.95, dim='sample')
+
+    # Top-5 by historical mean and bottom-5
+    hist_means = df.groupby('location')['disease_cases'].mean().sort_values(ascending=False)
+    pick = list(hist_means.head(5).index) + list(hist_means.tail(5).index)
+
+    print(f"{'location':14s} {'name':15s} {'hist_mean':>10s} {'eval_truth':>10s} {'pred_med':>10s} {'q05':>8s} {'q95':>8s}")
+    for loc in pick:
+        if loc not in locations:
+            continue
+        i = list(locations).index(loc)
+        # average across time/horizon for compact view
+        t_avg = truth.isel(location=i).mean().item()
+        m_avg = pred_med.isel(location=i).mean().item()
+        l_avg = pred_q05.isel(location=i).mean().item()
+        u_avg = pred_q95.isel(location=i).mean().item()
+        name = name_by_loc.get(loc, '?')[:14]
+        print(f"{loc:14s} {name:15s} {hist_means[loc]:>10.1f} {t_avg:>10.1f} {m_avg:>10.1f} {l_avg:>8.1f} {u_avg:>8.1f}")
+
+    # Per-horizon error
+    print("\nMAE per horizon (forecast 1m / 2m / 3m ahead):")
+    obs_b = truth.expand_dims({'horizon_distance': samples.sizes['horizon_distance']}, axis=-1)
+    err = (samples.mean('sample') - obs_b)
+    for h in range(samples.sizes['horizon_distance']):
+        vals = err.isel(horizon_distance=h).values.ravel()
+        vals = vals[~np.isnan(vals)]
+        print(f"  h={h}: bias {vals.mean():>+8.2f}  MAE {np.abs(vals).mean():>8.2f}  RMSE {np.sqrt((vals**2).mean()):>8.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/log_crps.py
+++ b/scripts/log_crps.py
@@ -1,0 +1,83 @@
+"""Compute log-CRPS for vnm_monthly_eval.nc.
+
+CRPS for a sample ensemble is:
+    CRPS(F, y) = (1/n) Σ |x_i - y|  -  (1/(2 n²)) Σ_{i,j} |x_i - x_j|
+
+Using the order-statistic identity
+    Σ_{i,j} |x_i - x_j| = 2 Σ_i (2i - n - 1) * x_(i)
+this can be computed in O(n log n) per cell. log-CRPS applies log1p to
+both samples and truth first so the metric is on a comparable scale
+across high- and low-incidence locations.
+"""
+from __future__ import annotations
+from pathlib import Path
+import numpy as np
+import xarray as xr
+
+NC = Path("/Users/knutdr/Sources/chtorch/vnm_monthly_eval.nc")
+
+
+def sample_crps(samples: np.ndarray, truth: np.ndarray) -> np.ndarray:
+    """Vectorised sample CRPS along the last axis of `samples`.
+
+    samples : (..., n)
+    truth   : (...)   — broadcastable to the prefix dims of samples
+    returns : (...) — CRPS per cell
+    """
+    n = samples.shape[-1]
+    truth = truth[..., None]  # broadcast against samples
+    term1 = np.mean(np.abs(samples - truth), axis=-1)
+
+    sorted_s = np.sort(samples, axis=-1)
+    # weights = (2i - n - 1) for i=1..n  →  -(n-1), -(n-3), ..., (n-1)
+    i = np.arange(1, n + 1)
+    weights = (2 * i - n - 1).astype(sorted_s.dtype)
+    term2 = (sorted_s * weights).sum(axis=-1) / (n * n)
+    return term1 - term2
+
+
+def main():
+    ds = xr.open_dataset(NC)
+    samples = ds["forecast"].values  # (loc, time, horizon, sample)
+    truth = ds["observed"].values    # (loc, time)
+
+    # Broadcast truth across horizon
+    horizon_n = samples.shape[2]
+    truth_b = np.broadcast_to(truth[:, :, None], samples.shape[:3])
+
+    # log-CRPS: transform both
+    log_samples = np.log1p(np.maximum(samples, 0))
+    log_truth = np.log1p(np.maximum(truth_b, 0))
+
+    crps_log = sample_crps(log_samples, log_truth)  # (loc, time, horizon)
+    crps_raw = sample_crps(samples, truth_b)
+
+    # Mask out cells where truth is NaN
+    mask = np.isfinite(truth_b)
+    print(f"valid cells: {mask.sum()} of {mask.size}")
+    print()
+    print("== Aggregate metrics ==")
+    print(f"  log-CRPS  (mean over all cells): {np.nanmean(np.where(mask, crps_log, np.nan)):.4f}")
+    print(f"  raw CRPS  (mean over all cells): {np.nanmean(np.where(mask, crps_raw, np.nan)):.2f}")
+
+    print("\n== Per horizon ==")
+    for h in range(horizon_n):
+        lc = np.nanmean(np.where(mask[:, :, h], crps_log[:, :, h], np.nan))
+        rc = np.nanmean(np.where(mask[:, :, h], crps_raw[:, :, h], np.nan))
+        print(f"  h={h}:  log-CRPS {lc:.4f}    raw CRPS {rc:.2f}")
+
+    print("\n== Per location (top 5 and bottom 5 by historical mean) ==")
+    # Reuse the historical observations to rank
+    hist = ds["historical_observed"].values
+    hist_mean = np.nanmean(hist, axis=1)
+    order = np.argsort(-hist_mean)
+    locs = ds.coords['location'].values
+    picks = list(order[:5]) + list(order[-5:])
+    for idx in picks:
+        loc = locs[idx]
+        lc = np.nanmean(np.where(mask[idx], crps_log[idx], np.nan))
+        print(f"  {loc:8s}  hist_mean={hist_mean[idx]:>8.1f}  log-CRPS={lc:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/log_crps_all.py
+++ b/scripts/log_crps_all.py
@@ -1,0 +1,53 @@
+"""Compute log-CRPS for every archived chap eval run on the VNM dataset."""
+from pathlib import Path
+import numpy as np
+import xarray as xr
+
+ROOT = Path("/Users/knutdr/chap-evaluations/mlruns/949198700587758246")
+
+LABELS = {
+    "3a9a5401bc0945ec8a1509b69a3218a2": "03:16  ep=30  num_workers=3  decay bug (10h run)",
+    "bcf75b4026b344d0ac1dd6070591533e": "11:02  ep=30  num_workers=0  decay bug (2m)",
+    "4161b4f5426e44b2a5d4ebfe85fa0f08": "11:41  ep=100 decay FIX",
+    "f564e440afcd40968c51a6f543822bff": "12:06  ep=100 + sin/cos + direct_ar + past_ratio=0.5",
+    "2b7c238512ff4baab3f5bfccf590343e": "12:12  + proper inverse  past_ratio=0.5",
+    "196561674db048ec8876fc95aea89f8a": "13:28  + proper inverse  past_ratio=0.2 (current)",
+}
+
+
+def sample_crps(samples, truth):
+    n = samples.shape[-1]
+    truth = truth[..., None]
+    term1 = np.mean(np.abs(samples - truth), axis=-1)
+    sorted_s = np.sort(samples, axis=-1)
+    i = np.arange(1, n + 1)
+    weights = (2 * i - n - 1).astype(sorted_s.dtype)
+    term2 = (sorted_s * weights).sum(axis=-1) / (n * n)
+    return term1 - term2
+
+
+def metrics_for_nc(nc_path):
+    ds = xr.open_dataset(nc_path)
+    samples = ds["forecast"].values
+    truth = ds["observed"].values
+    truth_b = np.broadcast_to(truth[:, :, None], samples.shape[:3])
+
+    log_s = np.log1p(np.maximum(samples, 0))
+    log_t = np.log1p(np.maximum(truth_b, 0))
+    crps_log = sample_crps(log_s, log_t)
+    mask = np.isfinite(truth_b)
+
+    overall = np.nanmean(np.where(mask, crps_log, np.nan))
+    per_h = [np.nanmean(np.where(mask[:, :, h], crps_log[:, :, h], np.nan)) for h in range(samples.shape[2])]
+    return overall, per_h
+
+
+print(f"{'label':70s}  {'mean':>7s}  {'h=0':>7s}  {'h=1':>7s}  {'h=2':>7s}")
+print("-" * 105)
+for run_id, label in LABELS.items():
+    nc = ROOT / run_id / "artifacts" / "vnm_monthly_eval.nc"
+    if not nc.exists():
+        print(f"MISSING: {nc}")
+        continue
+    overall, per_h = metrics_for_nc(nc)
+    print(f"{label:70s}  {overall:7.4f}  {per_h[0]:7.4f}  {per_h[1]:7.4f}  {per_h[2]:7.4f}")

--- a/scripts/probe_ar_attention.py
+++ b/scripts/probe_ar_attention.py
@@ -1,0 +1,65 @@
+"""Probe whether the model adapts predictions to recent cases.
+
+For a chosen location, show per-eval-period:
+  - truth observation
+  - the most recent 6 months of historical cases seen by the model
+  - prediction median (h=0)
+
+If the model is paying attention to the AR signal, prediction at time t
+should rise when the trailing context shows a surge.
+"""
+from pathlib import Path
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+NC = Path("/Users/knutdr/Sources/chtorch/lao_monthly_eval.nc")
+CSV = Path("/Users/knutdr/Data/CH/chap_LAO_admin1_monthly-3.csv")
+
+# Locations to inspect — the largest outbreak underpredictions
+PICKS = ["LA-VT", "LA-SV", "LA-CH", "LA-KH"]
+
+
+def main():
+    ds = xr.open_dataset(NC)
+    df = pd.read_csv(CSV)
+    df['time_period'] = pd.PeriodIndex(df['time_period'], freq='M')
+
+    samples = ds['forecast']
+    truth = ds['observed']
+    pred_med = samples.median('sample').values
+    pred_q05 = samples.quantile(0.05, dim='sample').values
+    pred_q95 = samples.quantile(0.95, dim='sample').values
+
+    # Time labels for the eval window (9 periods)
+    eval_periods = pd.PeriodIndex(ds['time_period'].values, freq='M')
+    locs = list(ds.coords['location'].values)
+
+    for loc in PICKS:
+        if loc not in locs:
+            continue
+        i = locs.index(loc)
+        loc_df = df[df.location == loc].sort_values('time_period').set_index('time_period')
+
+        print(f"\n==== {loc} ({loc_df['location_name'].iloc[0]}) ====")
+        print(f"{'eval_period':>12s} {'trail-6 cases (recent first)':>40s} {'truth':>8s} {'pred(h=0)':>10s} {'q05':>6s} {'q95':>8s}")
+
+        for j, p in enumerate(eval_periods):
+            # Build the trailing context — 6 months before this period
+            trail = []
+            for k in range(6):
+                pp = p - (k + 1)
+                if pp in loc_df.index:
+                    trail.append(loc_df.loc[pp, 'disease_cases'])
+                else:
+                    trail.append(float('nan'))
+            trail_str = "  ".join(f"{x:>5.0f}" if not np.isnan(x) else "  nan" for x in trail)
+            t = float(truth.values[i, j])
+            m = float(pred_med[i, j, 0])
+            lo = float(pred_q05[i, j, 0])
+            hi = float(pred_q95[i, j, 0])
+            print(f"   {str(p):>9s}  {trail_str:>40s}  {t:>8.0f}  {m:>10.1f}  {lo:>6.1f}  {hi:>8.1f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_auxilliary_estimator.py
+++ b/tests/test_auxilliary_estimator.py
@@ -35,7 +35,10 @@ def test_aux_get_transformed_dataset_returns_four_values(ch_dataset, auxilliary_
     estimator = _make_estimator(auxilliary_datasets)
     train, transformer, target_scaler, val = estimator._get_transformed_dataset(ch_dataset)
     assert isinstance(train, MultiDataset)
-    assert isinstance(target_scaler, MultiTargetScaler)
+    # target_scaler is None now that the per-location TargetScaler has been
+    # dropped. If a future change re-enables it (e.g. via config), this
+    # assertion should be updated to match.
+    assert target_scaler is None
     assert val is None  # no validation_dataset passed
 
 

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -92,8 +92,9 @@ def test_save_load_roundtrip_with_predict_nans(train_test, tmp_path):
         torch.testing.assert_close(loaded.module.state_dict()[k], v)
 
 
-def test_save_load_roundtrip_preserves_target_scaler(train_test, tmp_path):
-    import torch
+def test_save_load_roundtrip_target_scaler_none(train_test, tmp_path):
+    """Estimator.train no longer constructs a TargetScaler — save/load
+    must round-trip the absence cleanly."""
     from chtorch.estimator import Predictor
 
     train, _ = train_test
@@ -102,10 +103,11 @@ def test_save_load_roundtrip_preserves_target_scaler(train_test, tmp_path):
         ModelConfiguration(context_length=12),
     )
     predictor = estimator.train(train)
-    out_path = tmp_path / 'test_model_scaler'
+    assert predictor._target_scaler is None
+    out_path = tmp_path / 'test_model_no_scaler'
     predictor.save(out_path)
 
     loaded = Predictor.load(out_path)
-    assert loaded._target_scaler is not None
-    torch.testing.assert_close(loaded._target_scaler.mu, predictor._target_scaler.mu)
-    torch.testing.assert_close(loaded._target_scaler.std, predictor._target_scaler.std)
+    assert loaded._target_scaler is None
+    # No .target_scaler file should be written when there's nothing to save.
+    assert not out_path.with_suffix('.target_scaler').exists()


### PR DESCRIPTION
## Summary

Two architectural changes on the prediction head, plus the supporting infrastructure:

1. **Drop the per-location `TargetScaler`.** With `IncidenceRateTransform` the mean head already lives in `log1p(rate)` space; the per-loc shift+scale on top created a scale asymmetry (global stats on the input, per-loc stats on the output) that empirically dampened the model's response to recent surges.
2. **Persistence skip head + per-location std residual scaling.** The mean channel is now
   
   ```
   eta_mean = network_output * per_loc_std + last_log_rate
   ```
   
   `network_output = 0` ⇒ predict the most recent observation. Non-zero outputs are deviations in per-location-sigma units of `log1p(rate)`. The network only has to learn residuals — per-location baselines come for free regardless of training-set size.

A configurable toggle `persistence_skip: bool = True` is exposed for ablations.

## Results

Run on both the existing VNM monthly dataset and the LAO monthly dataset (smaller — 18 provinces vs 63), measuring sample-CRPS on `log1p`-transformed counts ("log-CRPS"):

| | VNM mean | LAO mean |
|---|---:|---:|
| pre-PR baseline (incidence-rate + TargetScaler) | 0.643 | 1.549 |
| drop TargetScaler | 0.602 | 1.877 |
| + persistence skip | 0.629 | 1.119 |
| **+ per-location std residual (HEAD)** | **0.598** | **1.120** |

**VNM: −7% vs baseline.** **LAO: −28% vs baseline.** The dataset-size sensitivity was the diagnosis we converged on: VNM has enough samples per location for the embedding to encode a per-location baseline; LAO doesn't, and the persistence skip is what makes the network responsive there. The AR-attention probe on LAO confirms it — pre-change the model predicted ~25 with `trail=1460` cases; now it tracks recent values almost exactly.

A full ablation (`persistence_skip: false`):

| Dataset | skip=True | skip=False |
|---|---:|---:|
| VNM mean log-CRPS | 0.598 | 0.668 |
| LAO mean log-CRPS | **1.120** | **3.550** |

Skip is load-bearing for LAO; we keep it as the default.

## Implementation

- `Estimator._get_single_transformed_dataset` now computes per-location std of `log1p(rate)` and returns `target_scaler=None`.
- `FlatTSDataSet` carries both `last_log_rate` (un-normalised, per-sample) and `per_loc_std` per location; `Entry` namedtuple has two new fields with `None` defaults.
- `FlatRNN.forward` accepts both as kwargs and applies the skip+scaling on the mean channel only (dispersion and any extra channels untouched).
- `Predictor` saves/loads `per_loc_std` via joblib next to the model state dict.
- `MultiDataset.__getitem__` rebuilt around `Entry._replace` so future Entry fields flow through unmodified.
- `distribution_loss._safe_total_count` got a `nan_to_num` + upper-bound clamp — without the persistence skip the network can output arbitrarily large/negative eta at init, producing NaN/inf in the NB total_count.

## Diagnostic scripts added under `scripts/`

- `log_crps.py` / `log_crps_all.py` — sample-CRPS computation (single + cross-run)
- `probe_ar_attention.py` — does the model actually use the most-recent observation?
- `inspect_eval.py` / `analyse_eval.py` — per-location prediction inspection
- `inspect_decay.py` — which params end up in which weight-decay bucket (turned up the `.0.` rule bug earlier)
- `bench_train_val.py` — per-epoch train + validation loss
- `bench_train.py` — single-train wall-clock + cProfile

## Test plan

- [x] `pytest tests/` → 41 passed, 2 skipped, 1 deselected (HPO is slow)
- [x] `chap eval` on VNM (`vnm_monthly_config.yaml`, persistence_skip=true) → 4 min, log-CRPS 0.598
- [x] `chap eval` on LAO (same config) → 4 min, log-CRPS 1.120
- [x] `chap eval` on the malaria/IRS spray dataset (different covariates) — runs end-to-end (~17 min, log-CRPS 0.392 — not directly comparable, different scale and 0% zero-rate)
- [x] Ablation `persistence_skip: false` confirms the toggle works and that the default is the right one

🤖 Generated with [Claude Code](https://claude.com/claude-code)